### PR TITLE
Add Feather RP2040 DVI support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,10 +104,12 @@ elseif ( INFONES_PLUS_HW_CONFIG EQUAL 3 )
 	set(NES_CLK "5" CACHE STRING "Select the Clock GPIO pin for NES controller")
 	set(NES_DATA "6" CACHE STRING "Select the Data GPIO pin for NES controller")
 	set(NES_LAT "9" CACHE STRING "Select the Latch GPIO pin for NES controller")
-	#set(WII_SDA "2" CACHE STRING "Select the SDA GPIO pin for Wii Classic controller")
-	#set(WII_SCL "3" CACHE STRING "Select the SCL GPIO pin for Wii Classic controller")
 	set(WII_SDA "-1" CACHE STRING "Select the SDA GPIO pin for Wii Classic controller")
 	set(WII_SCL "-1" CACHE STRING "Select the SCL GPIO pin for Wii Classic controller")
+	# IMPORTANT: DO NOT ENABLE SDA/SCL YET, FAILS CATASTROPHICALLY
+	# But once figured out, this is where that will go:
+	#set(WII_SDA "2" CACHE STRING "Select the SDA GPIO pin for Wii Classic controller")
+	#set(WII_SCL "3" CACHE STRING "Select the SCL GPIO pin for Wii Classic controller")
 endif ( )
 
 # --------------------------------------------------------------------
@@ -119,8 +121,8 @@ message("SD card MISO        : ${SD_MISO}")
 message("NES controller CLK  : ${NES_CLK}")
 message("NES controller DATA : ${NES_DATA}")
 message("NES controller LAT  : ${NES_LAT}")
-message("Wii controller SDA  : ${WII_SDA}")
-message("Wii controller SCL  : ${WII_SCL}")
+#message("Wii controller SDA  : ${WII_SDA}")
+#message("Wii controller SCL  : ${WII_SCL}")
 message("LED pin             : ${LED_GPIO_PIN}")
 
 if (  INFONES_PLUS_DISABLE_LED ) 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,8 @@ if ( INFONES_PLUS_HW_CONFIG EQUAL 1 )
 	set(NES_CLK "14" CACHE STRING "Select the Clock GPIO pin for NES controller")
 	set(NES_DATA "15" CACHE STRING "Select the Data GPIO pin for NES controller")
 	set(NES_LAT "16" CACHE STRING "Select the Latch GPIO pin for NES controller")
+	set(WII_SDA "-1" CACHE STRING "Select the SDA GPIO pin for Wii Classic controller")
+	set(WII_SCL "-1" CACHE STRING "Select the SCL GPIO pin for Wii Classic controller")
 elseif ( INFONES_PLUS_HW_CONFIG EQUAL 2 )
 	# --------------------------------------------------------------------
 	# Alternate config for use with different SDcard reader and HDMI board
@@ -86,6 +88,8 @@ elseif ( INFONES_PLUS_HW_CONFIG EQUAL 2 )
 	set(NES_CLK "6" CACHE STRING "Select the Clock GPIO pin for NES controller")
 	set(NES_DATA "7" CACHE STRING "Select the Data GPIO pin for NES controller")
 	set(NES_LAT "8" CACHE STRING "Select the Latch GPIO pin for NES controller")
+	set(WII_SDA "-1" CACHE STRING "Select the SDA GPIO pin for Wii Classic controller")
+	set(WII_SCL "-1" CACHE STRING "Select the SCL GPIO pin for Wii Classic controller")
 elseif ( INFONES_PLUS_HW_CONFIG EQUAL 3 )
 	# --------------------------------------------------------------------
 	# Alternate config for use with Adafruit Feather RP2040 DVI + SD Wing
@@ -100,6 +104,8 @@ elseif ( INFONES_PLUS_HW_CONFIG EQUAL 3 )
 	set(NES_CLK "5" CACHE STRING "Select the Clock GPIO pin for NES controller")
 	set(NES_DATA "6" CACHE STRING "Select the Data GPIO pin for NES controller")
 	set(NES_LAT "9" CACHE STRING "Select the Latch GPIO pin for NES controller")
+	set(WII_SDA "2" CACHE STRING "Select the SDA GPIO pin for Wii Classic controller")
+	set(WII_SCL "3" CACHE STRING "Select the SCL GPIO pin for Wii Classic controller")
 endif ( )
 
 # --------------------------------------------------------------------
@@ -111,6 +117,8 @@ message("SD card MISO        : ${SD_MISO}")
 message("NES controller CLK  : ${NES_CLK}")
 message("NES controller DATA : ${NES_DATA}")
 message("NES controller LAT  : ${NES_LAT}")
+message("Wii controller SDA  : ${WII_SDA}")
+message("Wii controller SCL  : ${WII_SCL}")
 message("LED pin             : ${LED_GPIO_PIN}")
 
 if (  INFONES_PLUS_DISABLE_LED ) 
@@ -124,6 +132,7 @@ add_executable(piconesPlus
     hid_app.cpp
     gamepad.cpp
     nespad.cpp
+    wiipad.cpp
     menu.cpp
     RomLister.cpp
     FrensHelpers.cpp
@@ -153,6 +162,8 @@ target_compile_definitions(piconesPlus PRIVATE
     NES_PIN_CLK=${NES_CLK}
     NES_PIN_DATA=${NES_DATA}
     NES_PIN_LAT=${NES_LAT}
+    WII_PIN_SDA=${WII_SDA}
+    WII_PIN_SCL=${WII_SCL}
     LED_GPIO_PIN=${LED_GPIO_PIN}
     LED_DISABLED=${LED_DISABLED}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,8 +104,10 @@ elseif ( INFONES_PLUS_HW_CONFIG EQUAL 3 )
 	set(NES_CLK "5" CACHE STRING "Select the Clock GPIO pin for NES controller")
 	set(NES_DATA "6" CACHE STRING "Select the Data GPIO pin for NES controller")
 	set(NES_LAT "9" CACHE STRING "Select the Latch GPIO pin for NES controller")
-	set(WII_SDA "2" CACHE STRING "Select the SDA GPIO pin for Wii Classic controller")
-	set(WII_SCL "3" CACHE STRING "Select the SCL GPIO pin for Wii Classic controller")
+	#set(WII_SDA "2" CACHE STRING "Select the SDA GPIO pin for Wii Classic controller")
+	#set(WII_SCL "3" CACHE STRING "Select the SCL GPIO pin for Wii Classic controller")
+	set(WII_SDA "-1" CACHE STRING "Select the SDA GPIO pin for Wii Classic controller")
+	set(WII_SCL "-1" CACHE STRING "Select the SCL GPIO pin for Wii Classic controller")
 endif ( )
 
 # --------------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,10 +57,12 @@ IF(EXISTS "${PICO_SDK_PATH}/lib/mbedtls")
 ENDIF()
 add_subdirectory(drivers/fatfs)
 add_subdirectory(drivers/sdcard)
-if ( NOT INFONES_PLUS_USE_ALTERNATE_HW_CONFIG ) 
+
+if ( INFONES_PLUS_HW_CONFIG EQUAL 1 )
 	# This default Config is for Pimoroni Pico DV Demo Base
 	set(DVICONFIG "dviConfig_PimoroniDemoDVSock" CACHE STRING
 	  "Select a default pin configuration from common_dvi_pin_configs.h")
+        set(LED_GPIO_PIN "25" CACHE STRING "Select the GPIO pin for LED")
 	set(SD_CS "22" CACHE STRING "Specify the Chip Select GPIO pin for the SD card")
 	set(SD_SCK "5" CACHE STRING "Specify de Clock GPIO pin for the SD card")
 	set(SD_MOSI "18" CACHE STRING "Select the Master Out Slave In GPIO pin for the SD card")
@@ -68,14 +70,14 @@ if ( NOT INFONES_PLUS_USE_ALTERNATE_HW_CONFIG )
 	set(NES_CLK "14" CACHE STRING "Select the Clock GPIO pin for NES controller")
 	set(NES_DATA "15" CACHE STRING "Select the Data GPIO pin for NES controller")
 	set(NES_LAT "16" CACHE STRING "Select the Latch GPIO pin for NES controller")
-else()
+elseif ( INFONES_PLUS_HW_CONFIG EQUAL 2 )
 	# --------------------------------------------------------------------
 	# Alternate config for use with different SDcard reader and HDMI board
 	# --------------------------------------------------------------------
 	# Adafruit DVI Breakout For HDMI Source Devices https://www.adafruit.com/product/4984
 	set(DVICONFIG "dviConfig_PicoDVISock" CACHE STRING
-	"Select a default pin configuration from common_dvi_pin_configs.h")
-
+	  "Select a default pin configuration from common_dvi_pin_configs.h")
+        set(LED_GPIO_PIN "25" CACHE STRING "Select the GPIO pin for LED")
 	# Adafruit Micro-SD breakout board+ https://www.adafruit.com/product/254 
 	set(SD_CS "5" CACHE STRING "Specify the Chip Select GPIO pin for the SD card")
 	set(SD_SCK "2" CACHE STRING "Specify de Clock GPIO pin for the SD card")
@@ -84,7 +86,22 @@ else()
 	set(NES_CLK "6" CACHE STRING "Select the Clock GPIO pin for NES controller")
 	set(NES_DATA "7" CACHE STRING "Select the Data GPIO pin for NES controller")
 	set(NES_LAT "8" CACHE STRING "Select the Latch GPIO pin for NES controller")
-endif ( NOT INFONES_PLUS_USE_ALTERNATE_HW_CONFIG )
+elseif ( INFONES_PLUS_HW_CONFIG EQUAL 3 )
+	# --------------------------------------------------------------------
+	# Alternate config for use with Adafruit Feather RP2040 DVI + SD Wing
+	# --------------------------------------------------------------------
+	set(DVICONFIG "dviConfig_AdafruitFeatherDVI" CACHE STRING
+	  "Select a default pin configuration from common_dvi_pin_configs.h")
+        set(LED_GPIO_PIN "13" CACHE STRING "Select the GPIO pin for LED")
+	set(SD_CS "10" CACHE STRING "Specify the Chip Select GPIO pin for the SD card")
+	set(SD_SCK "14" CACHE STRING "Specify de Clock GPIO pin for the SD card")
+	set(SD_MOSI "15" CACHE STRING "Select the Master Out Slave In GPIO pin for the SD card")
+	set(SD_MISO "8" CACHE STRING "Select the Master In Slave Out GPIO pin for the SD card")
+	set(NES_CLK "5" CACHE STRING "Select the Clock GPIO pin for NES controller")
+	set(NES_DATA "6" CACHE STRING "Select the Data GPIO pin for NES controller")
+	set(NES_LAT "9" CACHE STRING "Select the Latch GPIO pin for NES controller")
+endif ( )
+
 # --------------------------------------------------------------------
 message("HDMI board type     : ${DVICONFIG}")
 message("SD card CS          : ${SD_CS}")
@@ -94,13 +111,14 @@ message("SD card MISO        : ${SD_MISO}")
 message("NES controller CLK  : ${NES_CLK}")
 message("NES controller DATA : ${NES_DATA}")
 message("NES controller LAT  : ${NES_LAT}")
+message("LED pin             : ${LED_GPIO_PIN}")
 
 if (  INFONES_PLUS_DISABLE_LED ) 
     set(LED_DISABLED 1 CACHE STRING "Select whether to disable or enable the on board LED")
 else() 
     set(LED_DISABLED 0 CACHE STRING "Select whether to disable or enable the on board LED")
 endif (  INFONES_PLUS_DISABLE_LED )
-message("LED IS DISABLED     : ${LED_DISABLED}") 
+message("LED disabled        : ${LED_DISABLED}") 
 add_executable(piconesPlus
     main.cpp
     hid_app.cpp
@@ -135,6 +153,7 @@ target_compile_definitions(piconesPlus PRIVATE
     NES_PIN_CLK=${NES_CLK}
     NES_PIN_DATA=${NES_DATA}
     NES_PIN_LAT=${NES_LAT}
+    LED_GPIO_PIN=${LED_GPIO_PIN}
     LED_DISABLED=${LED_DISABLED}
 )
 target_link_libraries(piconesPlus PRIVATE

--- a/build.sh
+++ b/build.sh
@@ -12,7 +12,7 @@ if [ -d build ] ; then
 	mkdir build || exit 1
 fi
 cd build || exit 1
-cmake -DCMAKE_BUILD_TYPE=RELEASENODEBUG ..
+cmake -DCMAKE_BUILD_TYPE=RELEASENODEBUG -DINFONES_PLUS_HW_CONFIG=1 ..
 make -j 4
 cd ..
 . ./removetmpsdk.sh

--- a/buildAll.sh
+++ b/buildAll.sh
@@ -5,6 +5,7 @@
 # Binaries are copied to the releases folder
 #   - piconesPlusPimoroniDV.uf2     Pimoroni Pico DV Demo Base
 #   - piconesPlusAdaFruitDVISD.uf2  AdaFruit HDMI and SD Breakout boards
+#   - piconesPlusFeatherDVI.uf2     Adafruit Feather RP2040 DVI + SD Wing
 # ====================================================================================
 export RETAINSDK=1
 cd `dirname $0` || exit 1
@@ -18,6 +19,11 @@ cd `dirname $0` || exit 1
 ./build_alternate.sh
 if [ -f build/piconesPlus.uf2 ] ; then
 	cp build/piconesPlus.uf2 releases/piconesPlusAdaFruitDVISD.uf2 || exit 1
+fi
+cd `dirname $0` || exit 1
+./build_feather_dvi.sh
+if [ -f build/piconesPlus.uf2 ] ; then
+	cp build/piconesPlus.uf2 releases/piconesPlusFeatherDVI.uf2 || exit 1
 fi
 ls -l releases
 unset RETAINSDK

--- a/build_alternate_debug.sh
+++ b/build_alternate_debug.sh
@@ -16,7 +16,7 @@ if [ -d build ] ; then
 	mkdir build || exit 1
 fi
 cd build || exit 1
-cmake -DCMAKE_BUILD_TYPE=DEBUG -DINFONES_PLUS_USE_ALTERNATE_HW_CONFIG=1 ..
+cmake -DCMAKE_BUILD_TYPE=DEBUG -DINFONES_PLUS_HW_CONFIG=2 ..
 make -j 4
 cd ..
 . ./removetmpsdk.sh

--- a/build_debug.sh
+++ b/build_debug.sh
@@ -12,7 +12,7 @@ if [ -d build ] ; then
 	mkdir build || exit 1
 fi
 cd build || exit 1
-cmake -DCMAKE_BUILD_TYPE=DEBUG ..
+cmake -DCMAKE_BUILD_TYPE=DEBUF -DINFONES_PLUS_HW_CONFIG=1 ..
 make -j 4
 cd ..
 . ./removetmpsdk.sh

--- a/build_feather_dvi.sh
+++ b/build_feather_dvi.sh
@@ -2,12 +2,9 @@
 # ====================================================================================
 # PICO-INFONESPLUS build script with alternate configuration
 # Builds the emulator for use with the
-# AdaFruit DVI Breakout Board
-#         https://www.adafruit.com/product/4984
-#         https://learn.adafruit.com/adafruit-dvi-breakout-board
+# Adafruit Feather RP2040 DVI
 # and the 
-# AdaFruit  MicroSD card breakout board+
-#         https://www.adafruit.com/product/254 
+# Adafruit microSD Card FeatherWing
 # ====================================================================================
 cd `dirname $0` || exit 1
 . ./checksdk.sh
@@ -16,7 +13,7 @@ if [ -d build ] ; then
 	mkdir build || exit 1
 fi
 cd build || exit 1
-cmake -DCMAKE_BUILD_TYPE=RELEASENODEBUG -DINFONES_PLUS_HW_CONFIG=2 ..
+cmake -DCMAKE_BUILD_TYPE=RELEASENODEBUG -DINFONES_PLUS_HW_CONFIG=3 ..
 make -j 4
 cd ..
 . ./removetmpsdk.sh

--- a/build_feather_dvi_debug.sh
+++ b/build_feather_dvi_debug.sh
@@ -1,13 +1,10 @@
 :
 # ====================================================================================
-# PICO-INFONESPLUS build script with alternate configuration
+# PICO-INFONESPLUS build script with alternate configuration and debug enabled
 # Builds the emulator for use with the
-# AdaFruit DVI Breakout Board
-#         https://www.adafruit.com/product/4984
-#         https://learn.adafruit.com/adafruit-dvi-breakout-board
+# Adafruit Feather RP2040 DVI
 # and the 
-# AdaFruit  MicroSD card breakout board+
-#         https://www.adafruit.com/product/254 
+# Adafruit microSD Card FeatherWing
 # ====================================================================================
 cd `dirname $0` || exit 1
 . ./checksdk.sh
@@ -16,7 +13,7 @@ if [ -d build ] ; then
 	mkdir build || exit 1
 fi
 cd build || exit 1
-cmake -DCMAKE_BUILD_TYPE=RELEASENODEBUG -DINFONES_PLUS_HW_CONFIG=2 ..
+cmake -DCMAKE_BUILD_TYPE=DEBUG -DINFONES_PLUS_HW_CONFIG=3 ..
 make -j 4
 cd ..
 . ./removetmpsdk.sh

--- a/main.cpp
+++ b/main.cpp
@@ -41,7 +41,7 @@
 
 
 #if LED_DISABLED == 0
-const uint LED_PIN = PICO_DEFAULT_LED_PIN;
+const uint LED_PIN = LED_GPIO_PIN;
 #endif 
 #ifndef DVICONFIG
 #define DVICONFIG dviConfig_PimoroniDemoDVSock
@@ -73,6 +73,12 @@ namespace
     constexpr dvi::Config dviConfig_PimoroniDemoDVSock = {
         .pinTMDS = {8, 10, 12},
         .pinClock = 6,
+        .invert = true,
+    };
+    // Adafruit Feather RP2040 DVI
+    constexpr dvi::Config dviConfig_AdafruitFeatherDVI = {
+        .pinTMDS = {18, 20, 22},
+        .pinClock = 16,
         .invert = true,
     };
 

--- a/main.cpp
+++ b/main.cpp
@@ -32,6 +32,7 @@
 #include "rom_selector.h"
 #include "menu.h"
 #include "nespad.h"
+#include "wiipad.h"
 
 #ifdef __cplusplus
 
@@ -328,6 +329,9 @@ void InfoNES_PadState(DWORD *pdwPad1, DWORD *pdwPad2, DWORD *pdwSystem)
                 (gp.buttons & io::GamePadState::Button::START ? START : 0) |
                 0;
         if (i == 0) v |= nespad_state;
+#if WII_PIN_SDA >= 0 and WII_PIN_SCL >= 0
+            v |= wiipad_read();
+#endif
 
         int rv = v;
         if (rapidFireCounter & 2)
@@ -803,6 +807,9 @@ int main()
     applyScreenMode();
 
     nespad_begin(CPUFreqKHz, NES_PIN_CLK, NES_PIN_DATA, NES_PIN_LAT);
+#if WII_PIN_SDA >= 0 and WII_PIN_SCL >= 0
+    wiipad_begin();
+#endif
 
     // 空サンプル詰めとく
     dvi_->getAudioRingBuffer().advanceWritePointer(255);

--- a/menu.cpp
+++ b/menu.cpp
@@ -13,6 +13,7 @@
 #include "RomLister.h"
 #include "menu.h"
 #include "nespad.h"
+#include "wiipad.h"
 
 #include "font_8x8.h"
 #define FONT_CHAR_WIDTH 8
@@ -89,6 +90,9 @@ void RomSelect_PadState(DWORD *pdwPad1, bool ignorepushed = false)
             (gp.buttons & io::GamePadState::Button::Y ? Y : 0) |
             0;
     v |= nespad_state;
+#if WII_PIN_SDA >= 0 and WII_PIN_SCL >= 0
+    v |= wiipad_read();
+#endif
 
     *pdwPad1 = 0;
    

--- a/menu.cpp
+++ b/menu.cpp
@@ -675,6 +675,10 @@ void menu(uintptr_t NES_FILE_ADDR, char *errorMessage, bool isFatal)
             break;
         }
     }
+#if WII_PIN_SDA >= 0 and WII_PIN_SCL >= 0
+    wiipad_end();
+#endif
+
     // Don't return from this function call, but reboot in order to get the sound properly working
     // Starting emulator after return from menu often disables or corrupts sound
     // After reboot, the emulator starts the selected game.

--- a/wiipad.cpp
+++ b/wiipad.cpp
@@ -46,4 +46,12 @@ uint8_t wiipad_read(void) {
     return v;
 }
 
+void wiipad_end(void) {
+    i2c_deinit(WII_I2C);
+    gpio_set_pulls(WII_PIN_SDA, 0, 0);
+    gpio_set_pulls(WII_PIN_SCL, 0, 0);
+    gpio_set_function(WII_PIN_SDA, GPIO_FUNC_NULL);
+    gpio_set_function(WII_PIN_SCL, GPIO_FUNC_NULL);
+}
+
 #endif // end WII_PIN_SDA + WII_PIN_SCL

--- a/wiipad.cpp
+++ b/wiipad.cpp
@@ -1,3 +1,8 @@
+// Support for Wii Classic Controller and similar devices over I2C
+// SHOULD NOT BE USED right now. Although it "works" in the sense
+// that the game-select menu can be navigated, program CRASHES HARD
+// when copying ROM file to flash. Perhaps RAM constraint or ?
+
 #if WII_PIN_SDA >= 0 and WII_PIN_SCL >= 0
 
 #include "pico/stdlib.h"

--- a/wiipad.cpp
+++ b/wiipad.cpp
@@ -1,0 +1,49 @@
+#if WII_PIN_SDA >= 0 and WII_PIN_SCL >= 0
+
+#include "pico/stdlib.h"
+#include "hardware/i2c.h"
+#include "wiipad.h"
+
+void wiipad_begin(void) {
+    i2c_init(WII_I2C, 400000);
+    gpio_set_function(WII_PIN_SDA, GPIO_FUNC_I2C);
+    gpio_set_function(WII_PIN_SCL, GPIO_FUNC_I2C);
+    gpio_pull_up(WII_PIN_SDA);
+    gpio_pull_up(WII_PIN_SCL);
+    uint8_t init1[] = { 0xF0, 0x55 };
+    uint8_t init2[] = { 0xFB, 0x00 };
+    i2c_write_timeout_us(WII_I2C, WII_ADDR, init1, 2, false, 100);
+    sleep_ms(100);
+    i2c_write_timeout_us(WII_I2C, WII_ADDR, init2, 2, false, 100);
+}
+
+uint8_t wiipad_read(void) {
+    static constexpr int LEFT = 1 << 6;
+    static constexpr int RIGHT = 1 << 7;
+    static constexpr int UP = 1 << 4;
+    static constexpr int DOWN = 1 << 5;
+    static constexpr int SELECT = 1 << 2;
+    static constexpr int START = 1 << 3;
+    static constexpr int A = 1 << 0;
+    static constexpr int B = 1 << 1;
+
+    uint8_t v = 0;
+    uint8_t req[] = { 0x00 };
+    uint8_t buf[6];
+    i2c_write_timeout_us(WII_I2C, WII_ADDR, req, 1, false, 100);
+    sleep_us(200);
+    if (i2c_read_timeout_us(WII_I2C, WII_ADDR, buf, sizeof buf, false, 600) == sizeof buf) {
+        if (!(buf[5] & 0x01)) v |= UP;
+        if (!(buf[4] & 0x40)) v |= DOWN;
+        if (!(buf[5] & 0x02)) v |= LEFT;
+        if (!(buf[4] & 0x80)) v |= RIGHT;
+        if (!(buf[5] & 0x10)) v |= A;
+        if (!(buf[5] & 0x40)) v |= B;
+        if (!(buf[4] & 0x10)) v |= SELECT;
+        if (!(buf[4] & 0x04)) v |= START;
+    }
+
+    return v;
+}
+
+#endif // end WII_PIN_SDA + WII_PIN_SCL

--- a/wiipad.h
+++ b/wiipad.h
@@ -5,3 +5,4 @@
 
 extern void wiipad_begin(void);
 extern uint8_t wiipad_read(void);
+extern void wiipad_end(void);

--- a/wiipad.h
+++ b/wiipad.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#define WII_I2C i2c1
+#define WII_ADDR 0x52
+
+extern void wiipad_begin(void);
+extern uint8_t wiipad_read(void);


### PR DESCRIPTION
Tested and works with NES controller. Includes code for Wii Classic Controller (I2C) but SHOULD NOT BE ENABLED right now; perhaps in the future if issues can be resolved.